### PR TITLE
Fix bad typing of `consent_string_v2:purposes_li_transparency`

### DIFF
--- a/src/consent_string_v2.erl
+++ b/src/consent_string_v2.erl
@@ -150,7 +150,7 @@ parse_range_or_bitfield(_) ->
     {error, invalid_entries}.
 
 -spec purposes_li_transparency(pos_integer() | [pos_integer()], consent()) ->
-          undefined | boolean().
+          boolean().
 
 purposes_li_transparency(PurposeId, Consent) when is_integer(PurposeId) ->
     purposes_li_transparency([PurposeId], Consent);


### PR DESCRIPTION
Discovered with Gradualizer:

```
XXXX.erl: The function call on line Y at column Z is expected to have type boolean() but it has type undefined | boolean()

        consent_string_v2:purposes_li_transparency(P, C) andalso
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

XXXX.erl: The function call on line Y at column Z is expected to have type boolean() but it has type undefined | boolean()

        consent_string_v2:purposes_li_transparency(P, C) andalso
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
