### PR TITLE
[DEGA-1453] Fix range search to include start and end values

### DIFF
--- a/src/consent_string_v2.erl
+++ b/src/consent_string_v2.erl
@@ -396,7 +396,7 @@ parse_entries(_, _, _) ->
 
 search_entries(_Id, []) ->
     false;
-search_entries(Id, [{Start, End} | _]) when Id > Start, Id < End->
+search_entries(Id, [{Start, End} | _]) when Id >= Start, Id =< End->
     true;
 search_entries(Id, [Value | _]) when Id =:= Value ->
     true;


### PR DESCRIPTION
Fixed bug where range search did not include start and end values.