### PR TITLE
Migrate documentation to ExDoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
           restore-keys: |
             ci-${{runner.os}}-${{env.cache-name}}-erlang_${{matrix.erlang}}-rebar3
             ci-${{runner.os}}-${{env.cache-name}}-erlang_${{matrix.erlang}}
-      - name: elvis
-        run: make elvis
+      - name: lint
+        run: make lint
       - name: xref
         run: make xref
       - name: eunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _build
 *.beam
+/doc/
+*.dump

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ dialyzer:
 	@echo "Running rebar3 dialyze..."
 	@$(REBAR3) dialyzer
 
-edoc:
-	@echo "Running rebar3 edoc..."
-	@$(REBAR3) as edoc edoc
+doc:
+	@echo "Running rebar3 ex_doc..."
+	@$(REBAR3) ex_doc
 
 elvis:
 	@echo "Running elvis rock..."
@@ -37,4 +37,4 @@ xref:
 	@echo "Running rebar3 xref..."
 	@$(REBAR3) xref
 
-.PHONY: clean compile dialyzer edoc elvis eunit xref
+.PHONY: clean compile dialyzer doc elvis eunit xref

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-ELVIS=./bin/elvis
-REBAR3=./bin/rebar3
+REBAR3 ?= rebar3
 
 all: compile
 
@@ -19,8 +18,8 @@ doc:
 	@echo "Running rebar3 ex_doc..."
 	@$(REBAR3) ex_doc
 
-elvis:
-	@echo "Running elvis rock..."
+lint:
+	@echo "Running rebar3 lint..."
 	@$(REBAR3) lint
 
 eunit:
@@ -31,10 +30,10 @@ escriptize:
 	@echo "Building cli..."
 	@$(REBAR3) do escriptize
 
-test: elvis xref eunit dialyzer
+test: lint xref eunit dialyzer
 
 xref:
 	@echo "Running rebar3 xref..."
 	@$(REBAR3) xref
 
-.PHONY: clean compile dialyzer doc elvis eunit xref
+.PHONY: clean compile dialyzer doc eunit lint xref

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ true
 
 ```makefile
 make dialyzer
-make elvis
+make lint
 make eunit
 make xref
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 IAB consent-string library
 
-[![Build Status](https://travis-ci.org/adgear/consent-string.svg?branch=master)](https://travis-ci.org/adgear/consent-string?branch=master)
+[![Build Status](https://github.com/adgear/consent-string/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/adgear/consent-string?branch=master)
 
 ## API
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,11 +1,17 @@
-{edoc_opts, [
-  {app_default, "http://www.erlang.org/doc/man"},
-  {doclet, edown_doclet},
-  {image, ""},
-  {includes, ["include"]},
-  {preprocess, true},
-  {stylesheet, ""},
-  {title, "consent_string"}
+{minimum_otp_vsn, "24"}.
+
+{project_plugins, [rebar3_ex_doc]}.
+
+{hex, [{doc, #{provider => ex_doc}}]}.
+{ex_doc, [
+  {package, false},
+  {extras, [
+    {"README.md", #{title => "Overview"}},
+    {"LICENSE", #{title => "License"}}
+  ]},
+  {main, "README.md"},
+  {homepage_url, "https://github.com/adgear/consent-string"},
+  {source_url, "https://github.com/adgear/consent-string"}
 ]}.
 
 {erl_opts, [
@@ -24,12 +30,6 @@
       warn_untyped_record,
       warn_unused_import,
       warn_unused_vars
-    ]}
-  ]},
-  {edoc, [
-    {deps, [
-      {edown,
-        {git, "https://github.com/uwiger/edown.git", {tag, "0.7"}}}
     ]}
   ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,3 @@
-{minimum_otp_vsn, "24"}.
-
 {project_plugins, [rebar3_ex_doc]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{project_plugins, [rebar3_ex_doc]}.
+{project_plugins, [rebar3_ex_doc, rebar3_lint]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.
 {ex_doc, [

--- a/src/consent_debug.erl
+++ b/src/consent_debug.erl
@@ -1,3 +1,4 @@
+%% @private
 -module(consent_debug).
 -include("consent_string.hrl").
 

--- a/src/consent_string.erl
+++ b/src/consent_string.erl
@@ -14,6 +14,7 @@
     main/1
 ]).
 
+%% @private
 -spec main(list()) -> no_return().
 main(Args) ->
     consent_string_cli:main(Args).

--- a/src/consent_string_cli.erl
+++ b/src/consent_string_cli.erl
@@ -1,6 +1,8 @@
+%% @private
 -module(consent_string_cli).
 -export([main/1]).
 -include("consent_string.hrl").
+
 
 -spec main(list()) -> no_return().
 main([]) ->


### PR DESCRIPTION
- Migrates the documentation framework to Elixir's ExDoc.
- Use rebar3_lint wrapper for elvis

Some modules, functions and other entry points were marked as private to hide them from the documentation.

The downside of switching to ExDoc is that at least OTP 24 is required to build the documentation.
This isn't an issue for our projects.

Preview:
![image](https://github.com/adgear/consent-string/assets/20448408/96e8e0a7-1f10-4e08-a095-de16f63acb39)
